### PR TITLE
Install build and development dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libfreetype6-dev \
     libpng-dev \
     libjpeg-dev \
-    libtiff5 \
+    libtiff6 \
     libopenjp2-7 \
-    tk \
-    tcl \
     python3-tk \
     pkg-config \
     libffi-dev \


### PR DESCRIPTION
Update apt packages in Dockerfile to resolve build errors on Debian Bookworm.

Replaced `libtiff5` with `libtiff6` and removed `tk`/`tcl` as `python3-tk` provides the necessary dependencies, addressing `apt-get install` failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6d2b258-f398-465b-bfe5-b009ac27ad5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6d2b258-f398-465b-bfe5-b009ac27ad5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

