### PR TITLE
Enable inline mode for telegram bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,8 +19,8 @@ import unicodedata
 import re
 
 from activity_reporter import create_reporter
-from telegram import Update
-from telegram.ext import Application, CommandHandler, ContextTypes
+from telegram import Update, InlineQueryResultArticle, InputTextMessageContent
+from telegram.ext import Application, CommandHandler, ContextTypes, InlineQueryHandler
 from telegram.error import NetworkError, TimedOut, Conflict, BadRequest
 
 # ==== תצורה ====
@@ -301,6 +301,83 @@ async def start(update: Update, _: ContextTypes.DEFAULT_TYPE):
         return await update.message.reply_text("/sh <פקודת shell>\n/py <קוד פייתון>\n/health\n/restart\n/env\n/reset\n/allow,/deny,/list,/update (מנהלי הרשאות לבעלים בלבד)\n(תמיכה ב-cd/export/unset, ושמירת cwd/env לסשן)")
 
 
+async def inline_query(update: Update, _: ContextTypes.DEFAULT_TYPE):
+    """תמיכה במצב אינליין: מציע תוצאות מסוג InlineQueryResultArticle.
+    - מסנן מתוך ALLOWED_CMDS לפי הטקסט שהוקלד
+    - מחזיר פאגינציה בעזרת next_offset
+    - מוסיף קיצורי דרך להרצת /sh או /py עם הטקסט המלא
+    """
+    try:
+        user_id = update.inline_query.from_user.id if update.inline_query and update.inline_query.from_user else 0
+    except Exception:
+        user_id = 0
+    reporter.report_activity(user_id)
+
+    q = (update.inline_query.query or "").strip() if update.inline_query else ""
+    offset_text = update.inline_query.offset if update.inline_query else ""
+    try:
+        current_offset = int(offset_text) if offset_text else 0
+    except ValueError:
+        current_offset = 0
+
+    PAGE_SIZE = 10
+    results = []
+
+    # קיצורי דרך: להכין הודעה עם /sh או /py עבור הטקסט השלם שהוקלד
+    if q:
+        results.append(
+            InlineQueryResultArticle(
+                id="sh-echo",
+                title=f"להריץ ב-/sh: {q}",
+                description="מכין הודעת /sh עם הטקסט שחיפשת",
+                input_message_content=InputTextMessageContent(f"/sh {q}")
+            )
+        )
+        results.append(
+            InlineQueryResultArticle(
+                id="py-echo",
+                title="להריץ ב-/py (בלוק קוד)",
+                description="מכין הודעת /py עם הטקסט שלך",
+                input_message_content=InputTextMessageContent(f"/py {q}")
+            )
+        )
+
+    # הצעות מתוך רשימת הפקודות המותרות, עם פאגינציה
+    candidates = sorted(ALLOWED_CMDS)
+    if q:
+        ql = q.lower()
+        candidates = [c for c in candidates if ql in c.lower()]
+
+    total = len(candidates)
+    page_slice = candidates[current_offset: current_offset + PAGE_SIZE]
+    for cmd in page_slice:
+        results.append(
+            InlineQueryResultArticle(
+                id=f"cmd-{cmd}",
+                title=f"/sh {cmd}",
+                description="לחיצה תכין הודעת /sh עם הפקודה",
+                input_message_content=InputTextMessageContent(f"/sh {cmd}")
+            )
+        )
+
+    next_offset = str(current_offset + PAGE_SIZE) if (current_offset + PAGE_SIZE) < total else ""
+
+    if not results:
+        results.append(
+            InlineQueryResultArticle(
+                id="help",
+                title="איך משתמשים באינליין?",
+                description="כתבו @שם_הבוט ואז טקסט לחיפוש, למשל 'curl'",
+                input_message_content=InputTextMessageContent("כדי להריץ פקודות: כתבו /sh <פקודה> או /py <קוד>")
+            )
+        )
+
+    try:
+        await update.inline_query.answer(results, cache_time=0, is_personal=True, next_offset=next_offset)
+    except BadRequest:
+        # במקרה של בעיית מזהים כפולים/קלט לא תקין, ננסה לענות ללא next_offset
+        await update.inline_query.answer(results, cache_time=0, is_personal=True)
+
 async def sh_cmd(update: Update, _: ContextTypes.DEFAULT_TYPE):
     reporter.report_activity(update.effective_user.id if update.effective_user else 0)
     if not allowed(update):
@@ -549,6 +626,7 @@ def main():
     while True:
         app = Application.builder().token(token).post_init(on_post_init).build()
 
+        app.add_handler(InlineQueryHandler(inline_query))
         app.add_handler(CommandHandler("start", start))
         app.add_handler(CommandHandler("sh", sh_cmd))
         app.add_handler(CommandHandler("py", py_cmd))


### PR DESCRIPTION
Add Telegram Inline Mode support to allow users to quickly execute commands and get suggestions from any chat.

This feature enables users to type `@botname` followed by a query in any chat, receiving instant suggestions for `/sh` commands or shortcuts to run `/sh` or `/py` with their full input, significantly improving the bot's accessibility and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c4eedc6-39f5-469f-8c8d-383635d90ba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c4eedc6-39f5-469f-8c8d-383635d90ba9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds inline query support that suggests allowed `/sh` commands and provides `/sh` and `/py` shortcuts with pagination.
> 
> - **Inline Mode Support**:
>   - Add `inline_query` handler to return `InlineQueryResultArticle` results filtered from `ALLOWED_CMDS` by query, with `next_offset` pagination and fallback on `BadRequest`.
>   - Provide shortcuts to prefill `/sh` and `/py` with the full user query.
> - **Wiring**:
>   - Import `InlineQueryResultArticle`, `InputTextMessageContent`, and `InlineQueryHandler`.
>   - Register `InlineQueryHandler(inline_query)` in application setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf7885cb5ee3c48d037d5fef0fe82985cb89dd31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->